### PR TITLE
Add new methods with filters to re-check requests containing `?contex…

### DIFF
--- a/CHANGELONG.md
+++ b/CHANGELONG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.0 - 2018-04-25
+### Added
+- Added new method `RestDispatch::queryParamContextIsEdit`
+- Added new method `RestDispatch::isUserAuthenticated`.
+
+### Updated
+- `RestDispatch::isUserAuthenticated` uses a new filter `RestDispatch::FILTER_CACHE_VALIDATE_AUTH` to re-check requests containing `?context=edit` to avoid race conditions where a non-auth request returns results from cache.
+
 ## 1.1.1 - 2018-04-23
 ### Updated
 - Version bump for packagist.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install this package, edit your `composer.json` file:
 ```js
 {
     "require": {
-        "dwnload/wp-rest-api-object-cache": "^1.1.1"
+        "dwnload/wp-rest-api-object-cache": "^1.2.0"
     }
 }
 ```
@@ -71,6 +71,7 @@ Filters
 | Dwnload\WpRestApi\WpAdmin\Admin::FILTER_SHOW_ADMIN_MENU | boolean **$show** |
 | Dwnload\WpRestApi\WpAdmin\Admin::FILTER_SHOW_ADMIN_BAR_MENU | boolean **$show** |
 | Dwnload\WpRestApi\RestApi\RestDispatch::FILTER_ALLOWED_CACHE_STATUS | array **$status** HTTP Header statuses (defaults to `array( 200 )` |
+| Dwnload\WpRestApi\RestApi\RestDispatch::FILTER_CACHE_VALIDATE_AUTH | boolean **$authenticated**<br>WP_REST_Request $request |
 
 How to use filters
 ----
@@ -110,6 +111,21 @@ add_filter( Admin::FILTER_CACHE_OPTIONS, function( array $options ) : array {
 } );
 ```
 
+**Validating user auth when `?context=edit`**
+
+```php
+use Dwnload\WpRestApi\RestApi\RestDispatch;
+add_filter( RestDispatch::FILTER_CACHE_VALIDATE_AUTH, function( bool $auth, WP_REST_Request $request ) : bool {
+	// If you are running the Basic Auth plugin.
+	if ( $GLOBALS['wp_json_basic_auth_error'] === true ) {
+        $authorized = true;
+    }
+    // Otherwise, maybe do some additional logic on the request for current user...
+
+    return $authorized;
+}, 10, 2 );
+```
+
 **Skipping cache**
 
 ```php
@@ -145,4 +161,14 @@ add_action( 'save_post', function( $post_id ) {
     call_user_func( [ ( WpRestApiCache::getRestDispatch(), 'wpCacheFlush' ] );
   }
 } );
+```
+
+**Maybe better to use `transition_post_status`**
+
+```php
+add_action( 'transition_post_status', function(  string $new_status, string $old_status, \WP_Post $post ) {
+  if ( 'publish' === $new_status || 'publish' === $old_status ) {
+    \wp_cache_flush();
+  }
+}, 99, 3 );
 ```

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dwnload/wp-rest-api-object-cache",
   "description": "Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.",
   "type": "wordpress-plugin",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "license": "MIT",
   "authors": [
     {

--- a/wp-rest-api-cache.php
+++ b/wp-rest-api-cache.php
@@ -4,7 +4,7 @@
  * Description: Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.
  * Author: Austin Passy
  * Author URI: http://github.com/thefrosty
- * Version: 1.1.1
+ * Version: 1.2.0
  * Requires at least: 4.9
  * Tested up to: 4.9
  * Requires PHP: 7.0


### PR DESCRIPTION
…t=edit` to avoid race conditions where a non-auth request returns results from cache