### PR TITLE
Fixes ballooned response sizes.

### DIFF
--- a/CHANGELONG.md
+++ b/CHANGELONG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.2 - 2018-04-30
+### Fixed
+- When endpoints have multiple posts, the request bubbles up and appends the results which leads to a body size X's the
+requests. In other words, it's bad. This adds static property cache to break out of the possible loop.
+
 ## 1.2.1 - 2018-04-30
 ### Updated
 - Fixes PHP Warning: call_user_func_array() expects parameter 1 to be a valid callback , cannot access protected method Dwnload\WpRestApi\WpAdmin\Admin::renderPage(). 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dwnload/wp-rest-api-object-cache",
   "description": "Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.",
   "type": "wordpress-plugin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "license": "MIT",
   "authors": [
     {

--- a/src/RestApi/RestDispatch.php
+++ b/src/RestApi/RestDispatch.php
@@ -79,8 +79,7 @@ class RestDispatch implements WpHooksInterface
         $key = $this->getCacheKey($request_uri, $server, $request);
 
         // Return the result if it's a non-readable (GET) method or it's been cached.
-        if (
-            $request->get_method() !== WP_REST_Server::READABLE ||
+        if ($request->get_method() !== WP_REST_Server::READABLE ||
             (! empty(self::$cached[$this->cleanKey($key)]) && self::$cached[$this->cleanKey($key)] === true)
         ) {
             return $result;
@@ -235,7 +234,10 @@ class RestDispatch implements WpHooksInterface
                 $options[Settings::EXPIRATION]
             );
             self::$cached[$this->cleanKey($key)] = \wp_cache_set(
-                $this->cleanKey($key), $result, $group, \absint($expire)
+                $this->cleanKey($key),
+                $result,
+                $group,
+                \absint($expire)
             );
 
             return $result;

--- a/wp-rest-api-cache.php
+++ b/wp-rest-api-cache.php
@@ -4,7 +4,7 @@
  * Description: Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.
  * Author: Austin Passy
  * Author URI: http://github.com/thefrosty
- * Version: 1.2.1
+ * Version: 1.2.2
  * Requires at least: 4.9
  * Tested up to: 4.9
  * Requires PHP: 7.0


### PR DESCRIPTION
When endpoints have multiple posts, the request bubbles up and appends the results which leads to a body size X's the requests. In other words, it's bad. This adds static property cache to break out of the possible loop.