### PR TITLE
Version 1.2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 
 php:
-  - '7.1'
   - '7.0'
+  - '7.1'
+  - '7.2'
 
 install: composer install
 

--- a/CHANGELONG.md
+++ b/CHANGELONG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.2.3 - 2018-05-30
+### Updated
+- Added permission check (`delete_users`) before adding admin bar node.
+- Change permission check on settings page from `manage_options` to `delete_users`.
+- Removed nonce check after successful cache flush for admin notice.
+
+### Added
+- PHP 7.2 to the Travis build.
+
 ## 1.2.2 - 2018-04-30
 ### Fixed
 - When endpoints have multiple posts, the request bubbles up and appends the results which leads to a body size X's the

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dwnload/wp-rest-api-object-cache",
   "description": "Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.",
   "type": "wordpress-plugin",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "license": "MIT",
   "authors": [
     {

--- a/wp-rest-api-cache.php
+++ b/wp-rest-api-cache.php
@@ -4,7 +4,7 @@
  * Description: Enable object caching for WordPress' REST API. Aids in increased response times of your applications endpoints.
  * Author: Austin Passy
  * Author URI: http://github.com/thefrosty
- * Version: 1.2.2
+ * Version: 1.2.3
  * Requires at least: 4.9
  * Tested up to: 4.9
  * Requires PHP: 7.0

--- a/wp-rest-api-cache.php
+++ b/wp-rest-api-cache.php
@@ -19,7 +19,7 @@ use TheFrosty\WpUtilities\Plugin\PluginFactory;
 
 PluginFactory::create('rest-api-object-cache')
     ->addOnHook(RestDispatch::class)
-	->addOnHook(Admin::class)
+    ->addOnHook(Admin::class)
     ->initialize();
 
 call_user_func_array(


### PR DESCRIPTION
- Added permission check (`delete_users`) before adding admin bar node.
- Change permission check on settings page from `manage_options` to `delete_users`.
- Removed nonce check after successful cache flush for admin notice.